### PR TITLE
collect pd.read_csv and fsspec.open storage options via CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ $ python hydrograph_stats.py hydrograph.csv --pretty-print
 }
 ```
 
+Hydrograph from `stdin`:
+```
+$ cat hydrograph.csv | python hydrograph_stats.py
+```
+
 Specify duration:
 ```
 $ python hydrograph_stats.py hydrograph.csv --duration 4H15min


### PR DESCRIPTION
Additional arguments to connect to cloud storage services:
* `--storage-options`: JSON string with options passed to the `storage_options` parameter of `pandas.read_csv`, for reading input hydrograph.
* `--out-fsspec-kwargs`: JSON string with options passed as keyword arguments to `fsspec.open` for writing output data.