### PR TITLE
write WAT task status to Redis

### DIFF
--- a/tests/aws_integration_test.py
+++ b/tests/aws_integration_test.py
@@ -5,6 +5,7 @@ import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
 import pytest
+from redis import Redis
 
 import json
 import os
@@ -21,6 +22,10 @@ S3_STORAGE_OPTIONS = json.dumps({
     },
 })
 S3_BUCKET = 'mybucket'
+
+REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
+REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))
+REDIS_DB = int(os.getenv('REDIS_DB', 0))
 
 
 s3 = boto3.resource('s3', endpoint_url=S3_ENDPOINT,
@@ -116,3 +121,6 @@ def test_azure_wat_payload():
     blob_content = get_s3_object_content('results-wat.json')
     result = json.loads(blob_content)
     assert result[0]['max'] == 9.447773309400784
+    r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
+    key = 'None_hydrograph_stats_R1_E1'
+    assert r.get(key) == 'done'

--- a/tests/az_integration_test.py
+++ b/tests/az_integration_test.py
@@ -4,6 +4,7 @@ from .resources import *
 from azure.storage.blob import BlobServiceClient, ContainerClient, BlobClient
 from azure.core.exceptions import ResourceExistsError
 import pytest
+from redis import Redis
 
 import json
 import os
@@ -18,6 +19,10 @@ AZURE_BLOB_SERVICE_CLIENT: BlobServiceClient = BlobServiceClient.from_connection
 AZURE_STORAGE_OPTIONS = json.dumps({
     'connection_string': AZURE_STORAGE_CONNECTION_STRING
 })
+
+REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
+REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))
+REDIS_DB = int(os.getenv('REDIS_DB', 0))
 
 
 def upload_blob(file_path: str, blob_name: str):
@@ -104,3 +109,6 @@ def test_azure_wat_payload():
     blob_content = get_blob_content('results-wat.json')
     result = json.loads(blob_content)
     assert result[0]['max'] == 9.447773309400784
+    r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
+    key = 'None_hydrograph_stats_R1_E1'
+    assert r.get(key) == 'done'

--- a/tests/new_aws_integration_test.py
+++ b/tests/new_aws_integration_test.py
@@ -5,6 +5,7 @@ import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
 import pytest
+from redis import Redis
 
 import json
 import os
@@ -21,6 +22,10 @@ S3_STORAGE_OPTIONS = json.dumps({
     },
 })
 S3_BUCKET = 'myotherbucket'
+
+REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
+REDIS_PORT = int(os.getenv('REDIS_PORT', 6379))
+REDIS_DB = int(os.getenv('REDIS_DB', 0))
 
 
 s3 = boto3.resource('s3', endpoint_url=S3_ENDPOINT,
@@ -121,3 +126,6 @@ def test_azure_wat_payload():
     blob_content = get_s3_object_content('data/realization_0/event_7/results-wat.json')
     result = json.loads(blob_content)
     assert result[0]['max'] == 9.447773309400784
+    r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
+    key = 'tbd/hydrographstats:v0.0.2_hydrograph_stats_R0_E7'
+    assert r.get(key) == 'done'

--- a/tests/redis_integration_test.py
+++ b/tests/redis_integration_test.py
@@ -72,7 +72,9 @@ def test_redis_wat_payload():
     main([
         '--wat-payload', f'redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}#{WAT_PAYLOAD_REDIS_YML}',
     ])
-    r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
+    r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
     assert r.exists('results-wat')
     result = json.loads(r.get('results-wat'))
     assert result[0]['max'] == 9.447773309400784
+    key = 'None_hydrograph_stats_R1_E1'
+    assert r.get(key) == 'done'


### PR DESCRIPTION
Write task status to Redis when `REDIS_HOST` environment variable is set and a WAT payload is provided. 
Use the following key:
![image](https://user-images.githubusercontent.com/5504267/169178804-8ad7f042-79b4-478a-a529-2df32cd59bb1.png)

Update integration tests to verify that task status is written.
