### PR TITLE
use pytest.approx for floating point comparison

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,18 +4,18 @@ services:
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
-      - "10000:10000"
-    entrypoint: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000"]
+      - "11000:11000"
+    entrypoint: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "11000"]
 
   minio:
     image: minio/minio
     environment:
       - MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE
       - MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-    command: server /data --address ":9990" --console-address ":9991"
+    command: server /data --address ":9900" --console-address ":9901"
     ports:
-      - '9990:9990'
-      - '9991:9991'
+      - '9900:9900'
+      - '9901:9901'
 
   redis:
     image: redis
@@ -26,8 +26,8 @@ services:
       - ./tests:/opt/hydrograph_stats/tests
       - ${PWD}/pytest.ini:/opt/hydrograph_stats/pytest.ini
     environment:
-      - AZ_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;
-      - S3_ENDPOINT=http://minio:9990
+      - AZ_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:11000/devstoreaccount1;
+      - S3_ENDPOINT=http://minio:9900
       - REDIS_HOST=redis
     entrypoint: ["pytest", "--verbose", "-m", "integration"]
     depends_on:

--- a/tests/aws_integration_test.py
+++ b/tests/aws_integration_test.py
@@ -11,7 +11,7 @@ import json
 import os
 
 
-S3_ENDPOINT = os.getenv('S3_ENDPOINT', 'http://localhost:9990')
+S3_ENDPOINT = os.getenv('S3_ENDPOINT', 'http://localhost:9900')
 AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE'
 AWS_SECRET_ACCESS_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 S3_STORAGE_OPTIONS = json.dumps({
@@ -77,9 +77,9 @@ def test_aws_read_csv():
         f's3://{S3_BUCKET}/{HYDROGRAPH_CSV}',
         '--storage-options', S3_STORAGE_OPTIONS,
     ])
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -89,9 +89,9 @@ def test_aws_read_usgs_rdb():
         '--storage-options', S3_STORAGE_OPTIONS,
         '--usgs-rdb'
     ])
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -105,13 +105,13 @@ def test_aws_out():
     assert s3_object_exists('results.json')
     obj_content = get_s3_object_content('results.json')
     result = json.loads(obj_content)
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
-def test_azure_wat_payload():
+def test_aws_wat_payload():
     main([
         '--wat-payload', f's3://{S3_BUCKET}/{WAT_PAYLOAD_AWS_YML}',
         '--wat-payload-fsspec-kwargs', S3_STORAGE_OPTIONS,
@@ -120,7 +120,7 @@ def test_azure_wat_payload():
     assert s3_object_exists('results-wat.json')
     blob_content = get_s3_object_content('results-wat.json')
     result = json.loads(blob_content)
-    assert result[0]['max'] == 9.447773309400784
+    assert result[0]['max'] == pytest.approx(9.447773309400784)
     r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
     key = 'None_hydrograph_stats_R1_E1'
     assert r.get(key) == 'done'

--- a/tests/az_integration_test.py
+++ b/tests/az_integration_test.py
@@ -12,7 +12,7 @@ import os
 
 AZURE_STORAGE_CONNECTION_STRING = os.getenv(
     "AZ_CONNECTION_STRING",
-    "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+    "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:11000/devstoreaccount1;"
 )
 AZURE_CONTAINER = 'mycontainer'
 AZURE_BLOB_SERVICE_CLIENT: BlobServiceClient = BlobServiceClient.from_connection_string(AZURE_STORAGE_CONNECTION_STRING)
@@ -65,9 +65,9 @@ def test_azure_read_csv():
         f'abfs://{AZURE_CONTAINER}/{HYDROGRAPH_CSV}',
         '--storage-options', AZURE_STORAGE_OPTIONS,
     ])
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -77,9 +77,9 @@ def test_azure_read_usgs_rdb():
         '--storage-options', AZURE_STORAGE_OPTIONS,
         '--usgs-rdb'
     ])
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -93,9 +93,9 @@ def test_azure_out():
     assert blob_exists('results.json')
     blob_content = get_blob_content('results.json')
     result = json.loads(blob_content)
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -108,7 +108,7 @@ def test_azure_wat_payload():
     assert blob_exists('results-wat.json')
     blob_content = get_blob_content('results-wat.json')
     result = json.loads(blob_content)
-    assert result[0]['max'] == 9.447773309400784
+    assert result[0]['max'] == pytest.approx(9.447773309400784)
     r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
     key = 'None_hydrograph_stats_R1_E1'
     assert r.get(key) == 'done'

--- a/tests/data/config_aws.yml
+++ b/tests/data/config_aws.yml
@@ -8,7 +8,7 @@ storage_options:
   key: 'AKIAIOSFODNN7EXAMPLE'
   secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
   client_kwargs:
-    endpoint_url: http://minio:9990
+    endpoint_url: http://minio:9900
 duration: 4H15min
 sep: ","
 col_idx_dt: 0
@@ -20,4 +20,4 @@ out_fsspec_kwargs:
   key: 'AKIAIOSFODNN7EXAMPLE'
   secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
   client_kwargs:
-    endpoint_url: http://minio:9990
+    endpoint_url: http://minio:9900

--- a/tests/data/config_az.yml
+++ b/tests/data/config_az.yml
@@ -5,7 +5,7 @@
 # - ./tests/data/hsm1.csv
 # - ./tests/data/hydrograph.csv
 storage_options:
-  connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+  connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:11000/devstoreaccount1;"
 duration: 4H15min
 sep: ","
 col_idx_dt: 0
@@ -14,4 +14,4 @@ usgs_rdb: false
 pretty_print: true
 # out: ./tests/data/results.json
 out_fsspec_kwargs:
-  connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+  connection_string: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:11000/devstoreaccount1;"

--- a/tests/new_aws_integration_test.py
+++ b/tests/new_aws_integration_test.py
@@ -82,9 +82,9 @@ def get_s3_object_content(key: str):
 #         f's3://{S3_BUCKET}/{HYDROGRAPH_CSV}',
 #         '--storage-options', S3_STORAGE_OPTIONS,
 #     ])
-#     assert result[0]['max'] == 47300.0
-#     assert result[0]['min'] == 14800.0
-#     assert result[0]['duration_max'] == 47225.0
+#     assert result[0]['max'] == pytest.approx(47300.0)
+#     assert result[0]['min'] == pytest.approx(14800.0)
+#     assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 # @pytest.mark.integration
@@ -94,9 +94,9 @@ def get_s3_object_content(key: str):
 #         '--storage-options', S3_STORAGE_OPTIONS,
 #         '--usgs-rdb'
 #     ])
-#     assert result[0]['max'] == 47300.0
-#     assert result[0]['min'] == 14800.0
-#     assert result[0]['duration_max'] == 47225.0
+#     assert result[0]['max'] == pytest.approx(47300.0)
+#     assert result[0]['min'] == pytest.approx(14800.0)
+#     assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 # @pytest.mark.integration
@@ -110,13 +110,13 @@ def get_s3_object_content(key: str):
 #     assert s3_object_exists('results.json')
 #     obj_content = get_s3_object_content('results.json')
 #     result = json.loads(obj_content)
-#     assert result[0]['max'] == 47300.0
-#     assert result[0]['min'] == 14800.0
-#     assert result[0]['duration_max'] == 47225.0
+#     assert result[0]['max'] == pytest.approx(47300.0)
+#     assert result[0]['min'] == pytest.approx(14800.0)
+#     assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
-def test_azure_wat_payload():
+def test_aws_wat_payload():
     main([
         '--wat-payload', f's3://{S3_BUCKET}/{WAT_PAYLOAD_YML}',
         '--wat-payload-fsspec-kwargs', S3_STORAGE_OPTIONS,
@@ -125,7 +125,7 @@ def test_azure_wat_payload():
     assert s3_object_exists('data/realization_0/event_7/results-wat.json')
     blob_content = get_s3_object_content('data/realization_0/event_7/results-wat.json')
     result = json.loads(blob_content)
-    assert result[0]['max'] == 9.447773309400784
+    assert result[0]['max'] == pytest.approx(9.447773309400784)
     r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
     key = 'tbd/hydrographstats:v0.0.2_hydrograph_stats_R0_E7'
     assert r.get(key) == 'done'

--- a/tests/redis_integration_test.py
+++ b/tests/redis_integration_test.py
@@ -37,9 +37,9 @@ def test_redis_read_csv():
     result = main([
         f'redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}#{HYDROGRAPH_CSV}',
     ])
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -48,9 +48,9 @@ def test_redis_read_usgs_rdb():
         f'redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}#{HYDROGRAPH_TXT}',
         '--usgs-rdb'
     ])
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -62,9 +62,9 @@ def test_redis_out():
     r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
     assert r.exists('results')
     result = json.loads(r.get('results'))
-    assert result[0]['max'] == 47300.0
-    assert result[0]['min'] == 14800.0
-    assert result[0]['duration_max'] == 47225.0
+    assert result[0]['max'] == pytest.approx(47300.0)
+    assert result[0]['min'] == pytest.approx(14800.0)
+    assert result[0]['duration_max'] == pytest.approx(47225.0)
 
 
 @pytest.mark.integration
@@ -75,6 +75,6 @@ def test_redis_wat_payload():
     r = Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
     assert r.exists('results-wat')
     result = json.loads(r.get('results-wat'))
-    assert result[0]['max'] == 9.447773309400784
+    assert result[0]['max'] == pytest.approx(9.447773309400784)
     key = 'None_hydrograph_stats_R1_E1'
     assert r.get(key) == 'done'


### PR DESCRIPTION
* Use `pytest.approx` for floating point comparison in integration tests.
* Running into new port issues on Windows. Not sure what changed on my machine, but some of the container ports are within restricted ranges. Changed `minio` and `azurite` container ports.
```
> netsh interface ipv4 show excludedportrange protocol=tcp

Protocol tcp Port Exclusion Ranges

Start Port    End Port
----------    --------
        80          80
...
      8005        8005
      9981       10080
...
```